### PR TITLE
Index uploaded spaces and dynamic search

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from pathlib import Path
 from .core.config import settings
 from .api.v1.endpoints import search
 from app.services.bm25 import bm25_engine
@@ -32,3 +33,8 @@ def ping():
 @app.on_event("startup")
 def on_startup():
     bm25_engine.index(space="supreme_court")
+    uploads_root = Path(settings.DATA_UPLOAD)
+    if uploads_root.exists():
+        for dir in uploads_root.iterdir():
+            if dir.is_dir():
+                bm25_engine.index(space=dir.name)


### PR DESCRIPTION
## Summary
- index all directories under `DATA_UPLOAD` on startup
- simplify search logic to validate space name and use BM25
- expose a new `/spaces` endpoint listing available spaces

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684da2a8717083229e81bf67ed216e17