### PR TITLE
Add simple auth and user spaces

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.api.v1.schemas import LoginRequest, LoginResponse, SpaceCreateRequest
+from app.dependencies import get_current_user
+from app.services.auth import authenticate, create_user_space, get_accessible_spaces, UserData
+from app.services.bm25 import bm25_engine
+
+router = APIRouter()
+
+@router.post("/login", response_model=LoginResponse)
+def login(req: LoginRequest):
+    token = authenticate(req.username, req.password)
+    if not token:
+        raise HTTPException(401, detail="Invalid credentials")
+    return LoginResponse(token=token)
+
+@router.get("/user/spaces")
+def list_user_spaces(user: UserData = Depends(get_current_user)):
+    return {"spaces": get_accessible_spaces(user.username)}
+
+@router.post("/user/spaces")
+def create_space(req: SpaceCreateRequest, user: UserData = Depends(get_current_user)):
+    try:
+        space_key = create_user_space(user.username, req.name)
+    except ValueError as e:
+        raise HTTPException(400, detail=str(e))
+    bm25_engine.index(space_key)
+    return {"space": space_key}

--- a/backend/app/api/v1/schemas.py
+++ b/backend/app/api/v1/schemas.py
@@ -45,3 +45,13 @@ class Citation(BaseModel):
 class ChatResponse(BaseModel):
     answer: str
     citations: List[Citation]
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+class LoginResponse(BaseModel):
+    token: str
+
+class SpaceCreateRequest(BaseModel):
+    name: str

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,0 +1,15 @@
+from fastapi import Header, HTTPException
+from app.services.auth import tokens_db, users_db, UserData
+
+
+def get_current_user(authorization: str = Header(None)) -> UserData:
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(401, detail="Invalid or missing Authorization header")
+    token = authorization[7:]
+    username = tokens_db.get(token)
+    if not username:
+        raise HTTPException(401, detail="Invalid token")
+    user = users_db.get(username)
+    if not user:
+        raise HTTPException(401, detail="User not found")
+    return user

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+import uuid
+from pathlib import Path
+
+from app.core.config import settings
+
+@dataclass
+class UserData:
+    username: str
+    password: str
+    spaces: List[str] = field(default_factory=list)
+    organization: Optional[str] = None
+
+@dataclass
+class OrgData:
+    name: str
+    spaces: List[str] = field(default_factory=list)
+    members: List[str] = field(default_factory=list)
+
+users_db: Dict[str, UserData] = {}
+orgs_db: Dict[str, OrgData] = {}
+tokens_db: Dict[str, str] = {}
+
+
+def init_data() -> None:
+    """Initialize a few demo users and organizations."""
+    if users_db:
+        return
+
+    org = OrgData(name="demo_org", spaces=["shared"])
+    orgs_db[org.name] = org
+
+    user = UserData(username="alice", password="alice", spaces=["personal"], organization=org.name)
+    users_db[user.username] = user
+    org.members.append(user.username)
+
+    for space in user.spaces:
+        Path(settings.DATA_UPLOAD, user.username, space).mkdir(parents=True, exist_ok=True)
+    for space in org.spaces:
+        Path(settings.DATA_UPLOAD, org.name, space).mkdir(parents=True, exist_ok=True)
+
+
+def authenticate(username: str, password: str) -> Optional[str]:
+    user = users_db.get(username)
+    if not user or user.password != password:
+        return None
+    token = uuid.uuid4().hex
+    tokens_db[token] = username
+    return token
+
+
+def get_accessible_spaces(username: str) -> List[str]:
+    user = users_db.get(username)
+    if not user:
+        return []
+    spaces = [f"{user.username}/{s}" for s in user.spaces]
+    if user.organization and user.organization in orgs_db:
+        spaces += [f"{user.organization}/{s}" for s in orgs_db[user.organization].spaces]
+    return spaces
+
+
+def create_user_space(username: str, name: str) -> str:
+    user = users_db[username]
+    if name in user.spaces:
+        raise ValueError("Space already exists")
+    user.spaces.append(name)
+    path = Path(settings.DATA_UPLOAD, username, name)
+    path.mkdir(parents=True, exist_ok=True)
+    return f"{username}/{name}"
+
+init_data()
+


### PR DESCRIPTION
## Summary
- implement simple in-memory users and organizations
- add login and user space management endpoints
- restrict search and upload endpoints to authorized spaces
- load user and org spaces on startup

## Testing
- `python -m py_compile backend/app/services/auth.py backend/app/dependencies.py backend/app/api/v1/endpoints/auth.py backend/app/api/v1/endpoints/search.py backend/app/api/v1/endpoints/files.py backend/app/main.py backend/app/api/v1/schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_684db2a7f8c48322a01a601967822818