### PR TITLE
Add authentication service tests

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,60 @@
+import sys
+from pathlib import Path
+import importlib
+
+import pytest
+
+# Add backend directory to path for package imports
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.core.config import settings
+import app.services.auth as auth
+
+
+@pytest.fixture()
+def auth_env(tmp_path, monkeypatch):
+    """Reset in-memory databases and prepare temp upload directory."""
+    monkeypatch.setattr(settings, "DATA_UPLOAD", str(tmp_path))
+    auth.users_db.clear()
+    auth.orgs_db.clear()
+    auth.tokens_db.clear()
+    auth.init_data()
+    return tmp_path
+
+
+def test_authenticate_success(auth_env):
+    token = auth.authenticate("alice", "alice")
+    assert token
+    assert auth.tokens_db[token] == "alice"
+
+
+def test_authenticate_wrong_password(auth_env):
+    assert auth.authenticate("alice", "wrong") is None
+
+
+def test_authenticate_unknown_user(auth_env):
+    assert auth.authenticate("bob", "whatever") is None
+
+
+def test_get_accessible_spaces(auth_env):
+    spaces = auth.get_accessible_spaces("alice")
+    assert "alice/personal" in spaces
+    assert "demo_org/shared" in spaces
+
+
+def test_create_user_space_valid(auth_env):
+    path = auth.create_user_space("alice", "newspace")
+    assert path.exists() and path.is_dir()
+    expected = Path(settings.DATA_UPLOAD) / "alice" / "newspace"
+    assert path == expected
+
+
+def test_create_user_space_invalid(auth_env):
+    with pytest.raises(ValueError):
+        auth.create_user_space("alice", "../bad")
+    with pytest.raises(ValueError):
+        auth.create_user_space("alice", "bad/name")
+    with pytest.raises(ValueError):
+        auth.create_user_space("alice", "bad\\name")


### PR DESCRIPTION
## Summary
- add unit tests covering authentication service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dc4bc0d748322b47e5b7d2bce3ada