### PR TITLE
Add frontend features for auth

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -1,8 +1,22 @@
 from fastapi import APIRouter, Depends, HTTPException
 
-from app.api.v1.schemas import LoginRequest, LoginResponse, SpaceCreateRequest
+from app.api.v1.schemas import (
+    LoginRequest,
+    LoginResponse,
+    SpaceCreateRequest,
+    RegisterRequest,
+    UserInfo,
+)
 from app.dependencies import get_current_user
-from app.services.auth import authenticate, create_user_space, get_accessible_spaces, UserData
+from app.services.auth import (
+    authenticate,
+    create_user_space,
+    get_accessible_spaces,
+    register_user,
+    user_exists,
+    get_user,
+    UserData,
+)
 from app.services.bm25 import bm25_engine
 
 router = APIRouter()
@@ -12,7 +26,38 @@ def login(req: LoginRequest):
     token = authenticate(req.username, req.password)
     if not token:
         raise HTTPException(401, detail="Invalid credentials")
-    return LoginResponse(token=token)
+    user = get_user(req.username)
+    return LoginResponse(
+        token=token,
+        first_name=user.first_name if user else None,
+        last_name=user.last_name if user else None,
+    )
+
+
+@router.get("/users/{username}/exists")
+def api_user_exists(username: str):
+    return {"exists": user_exists(username)}
+
+
+@router.post("/register", response_model=LoginResponse)
+def register(req: RegisterRequest):
+    try:
+        register_user(
+            req.username,
+            req.password,
+            req.first_name,
+            req.last_name,
+        )
+    except ValueError as e:
+        raise HTTPException(400, detail=str(e))
+
+    token = authenticate(req.username, req.password)
+    user = get_user(req.username)
+    return LoginResponse(
+        token=token,
+        first_name=user.first_name,
+        last_name=user.last_name,
+    )
 
 @router.get("/user/spaces")
 def list_user_spaces(user: UserData = Depends(get_current_user)):

--- a/backend/app/api/v1/schemas.py
+++ b/backend/app/api/v1/schemas.py
@@ -52,6 +52,21 @@ class LoginRequest(BaseModel):
 
 class LoginResponse(BaseModel):
     token: str
+    first_name: str | None = None
+    last_name: str | None = None
+
+
+class RegisterRequest(BaseModel):
+    username: str
+    password: str
+    first_name: str
+    last_name: str
+
+
+class UserInfo(BaseModel):
+    username: str
+    first_name: str
+    last_name: str
 
 class SpaceCreateRequest(BaseModel):
     name: str

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -9,6 +9,8 @@ from app.core.config import settings
 class UserData:
     username: str
     password: str
+    first_name: str = ""
+    last_name: str = ""
     spaces: List[str] = field(default_factory=list)
     organization: Optional[str] = None
 
@@ -21,6 +23,37 @@ class OrgData:
 users_db: Dict[str, UserData] = {}
 orgs_db: Dict[str, OrgData] = {}
 tokens_db: Dict[str, str] = {}
+
+
+def user_exists(username: str) -> bool:
+    """Return True if *username* is present in the in-memory DB."""
+    return username in users_db
+
+
+def register_user(username: str, password: str, first_name: str = "", last_name: str = "") -> UserData:
+    """Create a new user and return the created ``UserData``.
+
+    Raises ``ValueError`` if the user already exists.
+    """
+    if username in users_db:
+        raise ValueError("User already exists")
+
+    user = UserData(
+        username=username,
+        password=password,
+        first_name=first_name,
+        last_name=last_name,
+        spaces=["personal"],
+    )
+    users_db[username] = user
+    # create upload directory for the personal space
+    Path(settings.DATA_UPLOAD, username, "personal").mkdir(parents=True, exist_ok=True)
+    return user
+
+
+def get_user(username: str) -> Optional[UserData]:
+    """Return ``UserData`` for *username* or ``None``."""
+    return users_db.get(username)
 
 
 def init_data() -> None:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -57,3 +57,25 @@ def test_create_user_space_invalid(auth_env):
         auth.create_user_space("alice", "bad/name")
     with pytest.raises(ValueError):
         auth.create_user_space("alice", "bad\\name")
+
+
+def test_user_exists_and_get_user(auth_env):
+    assert auth.user_exists("alice")
+    assert not auth.user_exists("bob")
+    user = auth.get_user("alice")
+    assert user and user.username == "alice"
+
+
+def test_register_user(auth_env):
+    new_user = auth.register_user("bob", "secret", "Bob", "Builder")
+    assert new_user.username == "bob"
+    assert new_user.first_name == "Bob"
+    assert auth.user_exists("bob")
+    # personal upload dir created
+    path = Path(settings.DATA_UPLOAD) / "bob" / "personal"
+    assert path.exists() and path.is_dir()
+
+
+def test_register_user_duplicate(auth_env):
+    with pytest.raises(ValueError):
+        auth.register_user("alice", "pass")

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import Landing from "./routes/Landing";
 import Search from "./routes/Search";
 import Chat from "./routes/Chat";
 import Uploads from "./routes/Uploads";
+import Login from "./routes/Login";
 
 export default function App() {
   return (
@@ -15,6 +16,7 @@ export default function App() {
           <Route path="/search"  element={<Search />} />
           <Route path="/chat"    element={<Chat />} />
           <Route path="/uploads" element={<Uploads />} />
+          <Route path="/login"   element={<Login />} />
         </Routes>
       </main>
       <footer className="bg-white text-center py-2 text-sm text-gray-500 border-t">

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,13 +1,18 @@
 import { Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 
 export default function Navbar() {
+  const { user } = useAuth();
+
+  const initial = user?.first_name?.[0] || user?.email?.[0];
+
   return (
     <nav className="bg-white shadow-md">
       <div className="container mx-auto px-4 py-3 flex items-center justify-between">
         <Link to="/" className="text-2xl font-bold text-indigo-600">
           encuentra
         </Link>
-        <div className="space-x-4">
+        <div className="space-x-4 flex items-center">
           <Link to="/search" className="text-gray-600 hover:text-indigo-600">
             Search
           </Link>
@@ -17,6 +22,15 @@ export default function Navbar() {
           <Link to="/uploads" className="text-gray-600 hover:text-indigo-600">
             Uploads
           </Link>
+          {user ? (
+            <div className="w-8 h-8 rounded-full bg-indigo-600 text-white flex items-center justify-center">
+              {initial?.toUpperCase()}
+            </div>
+          ) : (
+            <Link to="/login" className="text-gray-600 hover:text-indigo-600">
+              Login
+            </Link>
+          )}
         </div>
       </div>
     </nav>

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,26 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(() => {
+    const raw = localStorage.getItem("auth");
+    return raw ? JSON.parse(raw) : null;
+  });
+
+  useEffect(() => {
+    if (user) {
+      localStorage.setItem("auth", JSON.stringify(user));
+    } else {
+      localStorage.removeItem("auth");
+    }
+  }, [user]);
+
+  return (
+    <AuthContext.Provider value={{ user, setUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client';
 import App from './App';
 import './index.css';
 import { BrowserRouter } from "react-router-dom";
+import { AuthProvider } from "./context/AuthContext";
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </AuthProvider>
   </StrictMode>,
 );

--- a/frontend/src/routes/Login.jsx
+++ b/frontend/src/routes/Login.jsx
@@ -1,0 +1,157 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+
+export default function Login() {
+  const navigate = useNavigate();
+  const { setUser } = useAuth();
+  const [email, setEmail] = useState("");
+  const [step, setStep] = useState("email"); // email, password, register
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [password, setPassword] = useState("");
+  const [password2, setPassword2] = useState("");
+  const [error, setError] = useState("");
+
+  const checkEmail = async () => {
+    if (!email) return;
+    const res = await fetch(
+      `http://localhost:8000/v1/users/${encodeURIComponent(email)}/exists`
+    );
+    const data = await res.json();
+    setStep(data.exists ? "password" : "register");
+  };
+
+  const handleLogin = async () => {
+    const res = await fetch("http://localhost:8000/v1/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: email, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setUser({
+        token: data.token,
+        email,
+        first_name: data.first_name,
+        last_name: data.last_name,
+      });
+      navigate("/");
+    } else {
+      setError("Invalid credentials");
+    }
+  };
+
+  const handleRegister = async () => {
+    if (password !== password2) {
+      setError("Passwords do not match");
+      return;
+    }
+    const res = await fetch("http://localhost:8000/v1/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        username: email,
+        password,
+        first_name: firstName,
+        last_name: lastName,
+      }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setUser({
+        token: data.token,
+        email,
+        first_name: data.first_name,
+        last_name: data.last_name,
+      });
+      navigate("/");
+    } else {
+      const info = await res.json().catch(() => ({}));
+      setError(info.detail || "Registration failed");
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center py-8">
+      <div className="w-full max-w-sm space-y-4">
+        {step === "email" && (
+          <>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="border p-2 w-full rounded"
+              placeholder="Email"
+            />
+            <button
+              onClick={checkEmail}
+              className="w-full bg-indigo-600 text-white p-2 rounded"
+            >
+              Continue
+            </button>
+          </>
+        )}
+
+        {step === "password" && (
+          <>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="border p-2 w-full rounded"
+              placeholder="Password"
+            />
+            <button
+              onClick={handleLogin}
+              className="w-full bg-indigo-600 text-white p-2 rounded"
+            >
+              Login
+            </button>
+          </>
+        )}
+
+        {step === "register" && (
+          <>
+            <input
+              type="text"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              className="border p-2 w-full rounded"
+              placeholder="First name"
+            />
+            <input
+              type="text"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              className="border p-2 w-full rounded"
+              placeholder="Last name"
+            />
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="border p-2 w-full rounded"
+              placeholder="Password"
+            />
+            <input
+              type="password"
+              value={password2}
+              onChange={(e) => setPassword2(e.target.value)}
+              className="border p-2 w-full rounded"
+              placeholder="Repeat password"
+            />
+            <button
+              onClick={handleRegister}
+              className="w-full bg-indigo-600 text-white p-2 rounded"
+            >
+              Register
+            </button>
+          </>
+        )}
+
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend backend with registration and user lookup helper
- add a login/registration flow in the frontend
- provide an auth context and navbar user initial display
- test new user registration helpers

## Testing
- `python3 -m pytest -q`
- `npm -C frontend run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684dca7a82688322a3d1a98b812344fc