### PR TITLE
Enable auth token in frontend and expose public space

### DIFF
--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from app.core.config import settings
 
+# Spaces that are accessible to all users
+PUBLIC_SPACES = ["supreme_court"]
 @dataclass
 class UserData:
     username: str
@@ -86,11 +88,11 @@ def authenticate(username: str, password: str) -> Optional[str]:
 def get_accessible_spaces(username: str) -> List[str]:
     user = users_db.get(username)
     if not user:
-        return []
+        return PUBLIC_SPACES.copy()
     spaces = [f"{user.username}/{s}" for s in user.spaces]
     if user.organization and user.organization in orgs_db:
         spaces += [f"{user.organization}/{s}" for s in orgs_db[user.organization].spaces]
-    return spaces
+    return PUBLIC_SPACES + spaces
 
 
 def create_user_space(username: str, name: str) -> Path:

--- a/frontend/src/hooks/useApi.jsx
+++ b/frontend/src/hooks/useApi.jsx
@@ -4,9 +4,18 @@
  * @param {string} params Query string, p.ej. "?q=delito&space=supreme_court"
  * @returns {Promise<any>}  JSON parseado
  */
-export const useApi = (path, params = "") =>
-  fetch(`http://localhost:8000/v1/${path}${params}`)
-    .then((res) => {
-      if (!res.ok) throw new Error(`API error ${res.status}`);
-      return res.json();
-    });
+export const useApi = (path, params = "", options = {}) => {
+  const raw = localStorage.getItem("auth");
+  const token = raw ? JSON.parse(raw).token : null;
+
+  const headers = { ...(options.headers || {}) };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  return fetch(`http://localhost:8000/v1/${path}${params}`, {
+    ...options,
+    headers,
+  }).then((res) => {
+    if (!res.ok) throw new Error(`API error ${res.status}`);
+    return res.json();
+  });
+};

--- a/frontend/src/routes/Chat.jsx
+++ b/frontend/src/routes/Chat.jsx
@@ -1,9 +1,18 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useApi } from "../hooks/useApi";
 
 export default function Chat() {
   const [question, setQuestion]   = useState("");
   const [messages, setMessages]   = useState([]); // {role,text,citations}
-  const [space, setSpace]         = useState("supreme_court");
+  const [spaces, setSpaces]       = useState([]);
+  const [space, setSpace]         = useState("");
+  useEffect(() => {
+    useApi("user/spaces").then((d) => {
+      const s = d.spaces || [];
+      setSpaces(s);
+      if (s.length > 0) setSpace(s[0]);
+    }).catch((e) => console.error("Failed to fetch spaces", e));
+  }, []);
   const [loading, setLoading]     = useState(false);
 
   const askBot = async (e) => {
@@ -14,12 +23,11 @@ export default function Chat() {
     setMessages((m) => [...m, userMsg]);
     setLoading(true);
 
-    const res = await fetch("http://localhost:8000/v1/chat", {
+    const data = await useApi("chat", "", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ question, space, }),
+      body: JSON.stringify({ question, space }),
     });
-    const data = await res.json();
     const botMsg = {
       role: "bot",
       text: data.answer,
@@ -39,8 +47,11 @@ export default function Chat() {
           onChange={(e) => setSpace(e.target.value)}
           className="border p-2 rounded"
         >
-          <option value="supreme_court">Supreme Court</option>
-          <option value="default">Impuestos Inmobiliarios</option>
+          {spaces.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
         </select>
       </div>
 

--- a/frontend/src/routes/Search.jsx
+++ b/frontend/src/routes/Search.jsx
@@ -1,17 +1,22 @@
 // frontend/src/routes/Search.jsx
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useApi } from "../hooks/useApi";
 
-const SPACE_OPTIONS = [
-  { value: "supreme_court", label: "Supreme Court" },
-  { value: "default",       label: "Impuestos Inmobiliarios" },
-];
 
 export default function Search() {
   const [q, setQ]           = useState("");
-  const [space, setSpace]   = useState(SPACE_OPTIONS[0].value);
+  const [spaces, setSpaces] = useState([]);
+  const [space, setSpace]   = useState("");
   const [results, setResults] = useState([]);
+  useEffect(() => {
+    useApi("user/spaces").then((d) => {
+      const s = d.spaces || [];
+      setSpaces(s);
+      if (s.length > 0) setSpace(s[0]);
+    }).catch((e) => console.error("Failed to fetch spaces", e));
+  }, []);
+
   const [loading, setLoading] = useState(false);
   const [feedbackById, setFeedbackById] = useState({});
   const [toast, setToast] = useState({ docId: null, msg: "" });
@@ -78,9 +83,9 @@ export default function Search() {
           value={space}
           onChange={(e) => setSpace(e.target.value)}
         >
-          {SPACE_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
+          {spaces.map((s) => (
+            <option key={s} value={s}>
+              {s}
             </option>
           ))}
         </select>


### PR DESCRIPTION
## Summary
- add `PUBLIC_SPACES` so everyone can search the Supreme Court corpus
- include bearer token automatically in `useApi`
- fetch user spaces for chat and search routes and display them

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ded94aa4c8322b45ca7aa817863ec