### PR TITLE
Add OpenSearch search backend and configurable selector

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,38 @@
+## Backend search backends
+
+The API can run either entirely in memory using the bundled BM25 index or
+delegate search to an external OpenSearch cluster. The backend is selected via
+the `SEARCH_BACKEND` environment variable (`bm25` by default).
+
+### Using the in-memory BM25 engine (default)
+
+No additional setup is required; the application will load
+`data/static_corpus/corpus.jsonl` at startup and keep all indexes in memory. The
+same code path is still used by the test suite.
+
+### Using OpenSearch
+
+1. **Install OpenSearch and create credentials.** Provision an OpenSearch
+   domain (self-hosted or managed). Create a user that has permissions to
+   create/delete indexes and run bulk indexing operations.
+2. **Set environment variables** (e.g. in `.env`):
+   ```env
+   SEARCH_BACKEND=opensearch
+   OPENSEARCH_HOSTS=https://your-cluster.example.com:9200
+   OPENSEARCH_USERNAME=your-user
+   OPENSEARCH_PASSWORD=your-password
+   # optional, but recommended when using HTTPS
+   OPENSEARCH_CA_CERT=/path/to/ca.pem
+   OPENSEARCH_INDEX_PREFIX=encuentra
+   ```
+3. **Start the API**. On startup the FastAPI app will synchronise the
+   filesystem corpus with OpenSearch by re-creating per-space indexes and
+   loading documents through the bulk API.
+4. **Uploading new files.** Whenever a user uploads documents the API calls the
+   selected backend's `index()` method; for OpenSearch this translates into a
+   fresh bulk import for that space.
+
+The OpenSearch backend currently stores documents with a Spanish analyser and
+expects the same filesystem layout used by the BM25 implementation. This keeps
+feature parity between both modes, enabling a gradual migration to a scalable
+search cluster while retaining the local developer experience.

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -17,7 +17,7 @@ from backend.app.services.auth import (
     get_user,
     UserData,
 )
-from backend.app.services.bm25 import bm25_engine
+from backend.app.services.search import search_engine
 
 router = APIRouter()
 
@@ -69,5 +69,5 @@ def create_space(req: SpaceCreateRequest, user: UserData = Depends(get_current_u
         space_key = create_user_space(user.username, req.name)
     except ValueError as e:
         raise HTTPException(400, detail=str(e))
-    bm25_engine.index(str(space_key))
+    search_engine.index(str(space_key))
     return {"space": space_key}

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -4,7 +4,7 @@ from fastapi.encoders import jsonable_encoder
 import json
 
 from backend.app.api.v1.schemas import ChatRequest, ChatResponse, Citation
-from backend.app.services.bm25 import bm25_engine
+from backend.app.services.search import search_engine
 from backend.app.dependencies import get_current_user
 from openai import OpenAI
 from backend.app.core.config import settings
@@ -40,7 +40,7 @@ def truncate_to_tokens(text: str, max_tokens: int) -> str:
 @router.post("/chat", response_model=ChatResponse, summary="Ask the legal assistant (BM25-doc RAG)")
 def chat(req: ChatRequest = Body(...), user=Depends(get_current_user)):
     # 1) retrieve top documents with BM25 (doc-level)
-    hits = bm25_engine.search(req.question, top_k=max(5, MAX_DOCS), space=req.space)
+    hits = search_engine.search(req.question, top_k=max(5, MAX_DOCS), space=req.space)
     if not hits:
         return ChatResponse(answer="No encontré evidencia suficiente en el corpus.", citations=[])
 
@@ -51,7 +51,7 @@ def chat(req: ChatRequest = Body(...), user=Depends(get_current_user)):
 
     for h in hits:
         doc_id = h["id"]
-        doc = bm25_engine.get_document_by_id(req.space, doc_id)
+        doc = search_engine.get_document_by_id(req.space, doc_id)
         if not doc:
             continue
         full_text = doc.get("text", "") or ""
@@ -105,7 +105,7 @@ def chat(req: ChatRequest = Body(...), user=Depends(get_current_user)):
 @router.post("/chat/stream", summary="Ask the legal assistant (streaming)")
 async def chat_stream(req: ChatRequest = Body(...), user=Depends(get_current_user)):
     # 1) retrieve top documents with BM25 (doc-level)
-    hits = bm25_engine.search(req.question, top_k=max(5, MAX_DOCS), space=req.space)
+    hits = search_engine.search(req.question, top_k=max(5, MAX_DOCS), space=req.space)
     if not hits:
         # send one-line NDJSON with a final answer and no citations
         def empty_gen():
@@ -134,7 +134,7 @@ async def chat_stream(req: ChatRequest = Body(...), user=Depends(get_current_use
 
     for h in hits:
         doc_id = h["id"]
-        doc = bm25_engine.get_document_by_id(req.space, doc_id)
+        doc = search_engine.get_document_by_id(req.space, doc_id)
         if not doc:
             continue
         full_text = doc.get("text", "") or ""

--- a/backend/app/api/v1/endpoints/chat_static.py
+++ b/backend/app/api/v1/endpoints/chat_static.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Body
 from ..schemas import ChatRequest, ChatResponse, Citation
-from backend.app.services.bm25 import bm25_engine      # later: transformer_engine, LLM
+from backend.app.services.search import search_engine      # later: transformer_engine, LLM
 from time import sleep  # Simulate processing time
 
 router = APIRouter()
@@ -13,7 +13,7 @@ def chat(req: ChatRequest = Body(...)):
     2. Return a placeholder answer.
     """
     sleep(1)  # Simulate processing time
-    hits = bm25_engine.search(req.question, top_k=1, space=req.space)
+    hits = search_engine.search(req.question, top_k=1, space=req.space)
     citation_objs = []
     file_url = None
     if hits:

--- a/backend/app/api/v1/endpoints/files.py
+++ b/backend/app/api/v1/endpoints/files.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import List
 import uuid
 
-from backend.app.services.bm25 import bm25_engine
+from backend.app.services.search import search_engine
 from backend.app.core.config import settings
 from backend.app.dependencies import get_current_user
 from backend.app.services.auth import get_accessible_spaces, UserData
@@ -48,7 +48,7 @@ async def upload_file(
         })
 
     # Rebuild index for this space so the new docs are searchable
-    bm25_engine.index(space)
+    search_engine.index(space)
 
     return {
         "space": space,

--- a/backend/app/api/v1/endpoints/search.py
+++ b/backend/app/api/v1/endpoints/search.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Query, HTTPException, Depends
 # from typing import List, Dict
 from ..schemas import SearchResponse, SearchResult
-from backend.app.services.bm25 import bm25_engine
+from backend.app.services.search import search_engine
 from backend.app.dependencies import get_current_user
 from backend.app.services.auth import get_accessible_spaces, UserData
 
@@ -23,9 +23,9 @@ def search(
     print(f"Received search query: '{q}' in space '{space}' with top_k={top_k}")
     if space not in get_accessible_spaces(user.username):
         raise HTTPException(403, detail="Space not accessible")
-    if space not in bm25_engine.bm25_models:
+    if not search_engine.has_space(space):
         raise HTTPException(400, detail=f"Unknown space '{space}'")
-    hits = bm25_engine.search(q, top_k, space)
+    hits = search_engine.search(q, top_k, space)
     results = [SearchResult(**hit) for hit in hits]
     return SearchResponse(query_log_id=1, results=results)
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -8,7 +8,18 @@ class Settings(BaseSettings):
     ALLOWED_ORIGINS: str ="http://localhost:5173"
     CORPUS_PATH: str = "data/static_corpus"
     DATA_UPLOAD: str = "backend/app/api/data/user_uploads"
-    
+
+    # Search backend configuration
+    SEARCH_BACKEND: str = "bm25"  # bm25 | opensearch
+    OPENSEARCH_HOSTS: str = "http://localhost:9200"
+    OPENSEARCH_INDEX_PREFIX: str = "encuentra"
+    OPENSEARCH_USERNAME: str | None = None
+    OPENSEARCH_PASSWORD: str | None = None
+    OPENSEARCH_VERIFY_CERTS: bool = True
+    OPENSEARCH_CA_CERT: str | None = None
+    OPENSEARCH_TIMEOUT: int = 30
+    OPENSEARCH_BULK_CHUNK_SIZE: int = 500
+
     OPENAI_API_KEY: str | None = None
     OPENAI_CHAT_MODEL: str = "gpt-5-mini"
     MAX_DOC_TOKENS: int = 2000

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 from .core.config import settings
 from .api.v1.endpoints import search
-from .services.bm25 import bm25_engine
+from .services.search import search_engine
 from .api.v1.endpoints import files
 from .api.v1.endpoints import chat
 from .api.v1.endpoints import auth
@@ -40,10 +40,10 @@ def ping():
 @app.on_event("startup")
 def on_startup():
     auth_service.init_data()
-    bm25_engine.index(space="supreme_court")
+    search_engine.index(space="supreme_court")
     uploads_root = Path(settings.DATA_UPLOAD)
     if uploads_root.exists():
         for path in uploads_root.glob("*/*"):
             if path.is_dir():
                 rel = path.relative_to(uploads_root)
-                bm25_engine.index(space=str(rel))
+                search_engine.index(space=str(rel))

--- a/backend/app/services/bm25.py
+++ b/backend/app/services/bm25.py
@@ -33,7 +33,7 @@ class BM25Search:
 
     def index(self, space="supreme_court"):
         """Load documents from CORPUS_PATH into BM25 index."""
-        
+
         print("Loading corpus and initializing BM25 index...")
         
         self.corpus[space] = []  # dict to hold documents for the space
@@ -80,6 +80,10 @@ class BM25Search:
         else:
             self.bm25_models[space] = None
         print("Done loading corpus and initializing BM25 index.")
+
+    def has_space(self, space: str) -> bool:
+        model = self.bm25_models.get(space)
+        return model is not None
 
     def get_document_by_id(self, space: str, doc_id: str) -> dict | None:
         """

--- a/backend/app/services/opensearch.py
+++ b/backend/app/services/opensearch.py
@@ -1,0 +1,297 @@
+"""OpenSearch-backed search service.
+
+This module mirrors the interface of :mod:`backend.app.services.bm25`
+so the rest of the application can switch between backends depending on
+``settings.SEARCH_BACKEND``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlparse
+
+from opensearchpy import OpenSearch, helpers
+from opensearchpy.exceptions import NotFoundError
+
+from ..core.config import settings
+
+
+class OpenSearchSearch:
+    def __init__(self) -> None:
+        self._client: OpenSearch | None = None
+
+    # ------------------------------------------------------------------
+    # Client helpers
+    # ------------------------------------------------------------------
+    def _build_hosts(self) -> tuple[list[dict[str, Any]], bool | None]:
+        hosts: list[dict[str, Any]] = []
+        use_ssl: bool | None = None
+
+        raw_hosts = [h.strip() for h in settings.OPENSEARCH_HOSTS.split(",") if h.strip()]
+        if not raw_hosts:
+            raise RuntimeError("OPENSEARCH_HOSTS is empty; cannot initialize OpenSearch client.")
+
+        for raw in raw_hosts:
+            if raw.startswith("http://") or raw.startswith("https://"):
+                parsed = urlparse(raw)
+                scheme = parsed.scheme or "http"
+                host = parsed.hostname or "localhost"
+                if parsed.port:
+                    port = parsed.port
+                else:
+                    port = 443 if scheme == "https" else 80
+                hosts.append({"host": host, "port": port})
+                if use_ssl is None:
+                    use_ssl = scheme == "https"
+            else:
+                if ":" in raw:
+                    host_part, port_part = raw.split(":", 1)
+                    try:
+                        port = int(port_part)
+                    except ValueError:
+                        port = 9200
+                    hosts.append({"host": host_part, "port": port})
+                else:
+                    hosts.append({"host": raw, "port": 9200})
+        return hosts, use_ssl
+
+    def _get_client(self) -> OpenSearch:
+        if self._client is None:
+            hosts, use_ssl = self._build_hosts()
+            auth = None
+            if settings.OPENSEARCH_USERNAME and settings.OPENSEARCH_PASSWORD:
+                auth = (settings.OPENSEARCH_USERNAME, settings.OPENSEARCH_PASSWORD)
+
+            client_kwargs: dict[str, Any] = {
+                "hosts": hosts,
+                "http_compress": True,
+                "timeout": settings.OPENSEARCH_TIMEOUT,
+                "verify_certs": settings.OPENSEARCH_VERIFY_CERTS,
+            }
+            if use_ssl is not None:
+                client_kwargs["use_ssl"] = use_ssl
+            if auth:
+                client_kwargs["http_auth"] = auth
+            if settings.OPENSEARCH_CA_CERT:
+                client_kwargs["ca_certs"] = settings.OPENSEARCH_CA_CERT
+
+            self._client = OpenSearch(**client_kwargs)
+        return self._client
+
+    # ------------------------------------------------------------------
+    # Index helpers
+    # ------------------------------------------------------------------
+    def _index_name(self, space: str) -> str:
+        safe = space.replace("/", "__").replace(" ", "_").lower()
+        safe = re.sub(r"[^a-z0-9_\-]+", "-", safe)
+        return f"{settings.OPENSEARCH_INDEX_PREFIX}-{safe}"
+
+    def _create_index_if_needed(self, client: OpenSearch, index_name: str) -> None:
+        if client.indices.exists(index=index_name):
+            return
+
+        body = {
+            "settings": {
+                "index": {
+                    "number_of_shards": 1,
+                    "number_of_replicas": 1,
+                },
+                "analysis": {
+                    "analyzer": {
+                        "spanish_default": {
+                            "type": "standard",
+                            "stopwords": "_spanish_",
+                        }
+                    }
+                },
+            },
+            "mappings": {
+                "properties": {
+                    "id": {"type": "keyword"},
+                    "title": {
+                        "type": "text",
+                        "analyzer": "spanish_default",
+                        "fields": {"raw": {"type": "keyword"}},
+                    },
+                    "text": {
+                        "type": "text",
+                        "analyzer": "spanish_default",
+                    },
+                    "space": {"type": "keyword"},
+                    "download_url": {"type": "keyword"},
+                }
+            },
+        }
+        client.indices.create(index=index_name, body=body)
+
+    def _resolve_download_url(self, doc_id: str) -> str | None:
+        files_root = Path(settings.CORPUS_PATH) / "files"
+        for ext in (".pdf", ".PDF", ".htm", ".html", ".HTML", ".docx", ".doc", ".txt"):
+            candidate = files_root / f"{doc_id}{ext}"
+            if candidate.exists():
+                return f"/files/{candidate.name}"
+        return None
+
+    def _load_documents(self, space: str) -> list[dict[str, Any]]:
+        documents: list[dict[str, Any]] = []
+
+        if space == "supreme_court":
+            jsonl_file = Path(settings.CORPUS_PATH) / "corpus.jsonl"
+            if not jsonl_file.exists():
+                print(f"[OpenSearch] corpus.jsonl not found for space '{space}'.")
+                return []
+            with jsonl_file.open(encoding="utf-8") as fh:
+                for line in fh:
+                    try:
+                        obj = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    doc_id = obj.get("id") or obj.get("doc_id")
+                    if not doc_id:
+                        continue
+                    title = obj.get("title", "")
+                    text = obj.get("text", "")
+                    content = f"{title} {text}".strip()
+                    documents.append(
+                        {
+                            "id": doc_id,
+                            "title": title,
+                            "text": content,
+                            "space": space,
+                            "download_url": self._resolve_download_url(doc_id),
+                        }
+                    )
+        else:
+            dir_path = Path(settings.DATA_UPLOAD) / space
+            if not dir_path.exists():
+                print(f"[OpenSearch] Upload directory '{dir_path}' missing for space '{space}'.")
+                return []
+            for file in dir_path.glob("**/*.txt"):
+                try:
+                    text = file.read_text(encoding="utf-8")
+                except UnicodeDecodeError:
+                    text = file.read_text(encoding="latin-1")
+                documents.append(
+                    {
+                        "id": file.stem,
+                        "title": file.stem,
+                        "text": text,
+                        "space": space,
+                        "download_url": None,
+                    }
+                )
+
+        return documents
+
+    def _bulk_actions(self, index_name: str, docs: Iterable[dict[str, Any]]):
+        for doc in docs:
+            yield {
+                "_op_type": "index",
+                "_index": index_name,
+                "_id": doc["id"],
+                "_source": doc,
+            }
+
+    # ------------------------------------------------------------------
+    # Public API (mirrors BM25Search)
+    # ------------------------------------------------------------------
+    def index(self, space: str = "supreme_court") -> None:
+        client = self._get_client()
+        index_name = self._index_name(space)
+
+        documents = self._load_documents(space)
+        if not documents:
+            # Ensure stale data is removed if the space becomes empty.
+            client.indices.delete(index=index_name, ignore=[400, 404])
+            print(f"[OpenSearch] No documents to index for space '{space}'.")
+            return
+
+        # Drop the existing index to keep things in sync with the filesystem snapshot.
+        client.indices.delete(index=index_name, ignore=[400, 404])
+        self._create_index_if_needed(client, index_name)
+
+        helpers.bulk(
+            client,
+            self._bulk_actions(index_name, documents),
+            chunk_size=settings.OPENSEARCH_BULK_CHUNK_SIZE,
+            refresh="wait_for",
+        )
+        print(f"[OpenSearch] Indexed {len(documents)} documents into '{index_name}'.")
+
+    def has_space(self, space: str) -> bool:
+        client = self._get_client()
+        index_name = self._index_name(space)
+        return bool(client.indices.exists(index=index_name))
+
+    def search(self, query: str, top_k: int = 30, space: str = "supreme_court") -> list[dict[str, Any]]:
+        client = self._get_client()
+        index_name = self._index_name(space)
+        if not client.indices.exists(index=index_name):
+            print(f"[OpenSearch] Index '{index_name}' missing for space '{space}'.")
+            return []
+
+        body = {
+            "size": top_k,
+            "query": {
+                "multi_match": {
+                    "query": query,
+                    "fields": ["title^2", "text"],
+                    "type": "best_fields",
+                }
+            },
+            "highlight": {
+                "fields": {
+                    "text": {
+                        "fragment_size": 200,
+                        "number_of_fragments": 1,
+                    }
+                }
+            },
+        }
+
+        response = client.search(index=index_name, body=body)
+        hits: list[dict[str, Any]] = []
+        for hit in response.get("hits", {}).get("hits", []):
+            source = hit.get("_source", {})
+            snippet = ""
+            highlight = hit.get("highlight", {}).get("text")
+            if highlight:
+                snippet = " … ".join(highlight)
+            else:
+                text = source.get("text", "")
+                snippet = " ".join(text.split()[:50])
+
+            hits.append(
+                {
+                    "id": source.get("id") or hit.get("_id"),
+                    "title": source.get("title", ""),
+                    "score": float(hit.get("_score") or 0.0),
+                    "snippet": snippet,
+                    "download_url": source.get("download_url"),
+                }
+            )
+        return hits
+
+    def get_document_by_id(self, space: str, doc_id: str) -> dict[str, Any] | None:
+        client = self._get_client()
+        index_name = self._index_name(space)
+        try:
+            doc = client.get(index=index_name, id=doc_id)
+        except NotFoundError:
+            return None
+
+        source = doc.get("_source", {})
+        return {
+            "id": doc_id,
+            "title": source.get("title", ""),
+            "text": source.get("text", ""),
+            "download_url": source.get("download_url"),
+        }
+
+
+opensearch_engine = OpenSearchSearch()
+

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -1,0 +1,30 @@
+"""Helper module to select the active search backend."""
+
+from __future__ import annotations
+
+from ..core.config import settings
+from .bm25 import bm25_engine
+
+try:
+    from .opensearch import opensearch_engine
+except Exception as exc:  # pragma: no cover - defensive fallback when dependency missing
+    opensearch_engine = None
+    _opensearch_error = exc
+else:
+    _opensearch_error = None
+
+
+def _select_engine():
+    backend = (settings.SEARCH_BACKEND or "bm25").lower()
+    if backend == "opensearch":
+        if opensearch_engine is None:
+            raise RuntimeError(
+                "SEARCH_BACKEND=opensearch but the OpenSearch client could not be initialised"
+                f": {_opensearch_error}"
+            )
+        return opensearch_engine
+    return bm25_engine
+
+
+search_engine = _select_engine()
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,7 @@ httptools==0.6.4
 idna==3.10
 joblib==1.5.1
 numpy==2.3.0
+opensearch-py==2.6.0
 pydantic==2.11.5
 pydantic-settings==2.9.1
 pydantic_core==2.33.2

--- a/backend/tests/test_search_chat_files.py
+++ b/backend/tests/test_search_chat_files.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import io
+
 import pytest
 
 from backend.app.core.config import settings
@@ -8,8 +9,14 @@ from backend.app.api.v1.endpoints import chat as chat_ep
 from backend.app.api.v1.endpoints import files as files_ep
 from backend.app.api.v1.schemas import ChatRequest
 from backend.app.services import auth
-from backend.app.services.bm25 import bm25_engine
+from backend.app.services.search import search_engine
 from starlette.datastructures import UploadFile
+
+
+pytestmark = pytest.mark.skipif(
+    settings.SEARCH_BACKEND != "bm25",
+    reason="Tests exercise the in-memory BM25 backend",
+)
 
 
 @pytest.fixture()
@@ -29,19 +36,19 @@ def test_env(tmp_path, monkeypatch):
     monkeypatch.setattr(search_ep, "get_accessible_spaces", lambda u: ["supreme_court", "alice/personal"])
 
     # Reset BM25 engine
-    bm25_engine.corpus.clear()
-    bm25_engine.tokenized.clear()
-    bm25_engine.bm25_models.clear()
+    search_engine.corpus.clear()
+    search_engine.tokenized.clear()
+    search_engine.bm25_models.clear()
 
     # Index the built-in supreme court corpus and a simple personal document
-    bm25_engine.index("supreme_court")
+    search_engine.index("supreme_court")
 
     # Create a simple document in alice's personal space
     uploads_dir = Path(settings.DATA_UPLOAD) / "alice" / "personal"
     uploads_dir.mkdir(parents=True, exist_ok=True)
     (uploads_dir / "doc1.txt").write_text("hello world test document", encoding="utf-8")
 
-    bm25_engine.index("alice/personal")
+    search_engine.index("alice/personal")
     return auth.get_user("alice")
 
 
@@ -69,7 +76,7 @@ def test_file_upload_creates_file_and_indexes(test_env, monkeypatch):
     def fake_index(space):
         indexed.append(space)
 
-    monkeypatch.setattr(bm25_engine, "index", fake_index)
+    monkeypatch.setattr(search_engine, "index", fake_index)
 
     import asyncio
     resp = asyncio.run(files_ep.upload_file(files=[uploaded], space="alice/personal", user=user))


### PR DESCRIPTION
## Summary
- add an OpenSearch-backed search service with configuration knobs and an engine selector
- update API endpoints, startup indexing, and tests to use the unified search engine API
- document how to switch between BM25 and OpenSearch and add the opensearch-py dependency

## Testing
- `PYTHONPATH=.. pytest tests/test_search_chat_files.py` *(fails: missing openai package in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e4464b40308322a5f037d1c833e1fd