### PR TITLE
feat(frontend): migrate chat UI to vercel ai sdk

### DIFF
--- a/frontend/src/routes/Chat.jsx
+++ b/frontend/src/routes/Chat.jsx
@@ -1,116 +1,179 @@
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useChat } from "ai/react";
 import { useApi } from "@/hooks/useApi";
 import SpaceSelect from "@/components/SpaceSelect";
 import ChatMessage from "@/components/ChatMessage";
 
+const encoder = new TextEncoder();
+const decoder = new TextDecoder("utf-8");
+
 export default function Chat() {
   const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:8000";
-  const [question, setQuestion] = useState("");
-  const [messages, setMessages] = useState([]); // {role,text,citations,file_url,streaming}
   const [spaces, setSpaces] = useState([]);
   const [space, setSpace] = useState("");
-  const [loading, setLoading] = useState(false);
+  const lastAssistantMetaRef = useRef({ citations: [], file_url: null });
 
   useEffect(() => {
     useApi("user/spaces")
       .then((d) => {
         const s = d.spaces || [];
         setSpaces(s);
-        if (s.length > 0) setSpace(s[0]);
+        if (s.length > 0) setSpace((curr) => curr || s[0]);
       })
       .catch((e) => console.error("Failed to fetch spaces", e));
   }, []);
 
-  const askBot = async (e) => {
-    e.preventDefault();
-    if (!question.trim()) return;
+  const body = useMemo(() => ({ space }), [space]);
 
-    // 1) add user message
-    const userMsg = { role: "user", text: question };
-    setMessages((m) => [...m, userMsg]);
-    setLoading(true);
+  const {
+    messages,
+    input,
+    handleInputChange,
+    handleSubmit,
+    isLoading,
+    setMessages,
+  } = useChat({
+    api: `${API_BASE}/v1/chat/stream`,
+    body,
+    sendExtraMessageFields: true,
+    fetch: async (_input, init) => {
+      let rawBody = {};
+      if (init?.body) {
+        try {
+          rawBody = JSON.parse(init.body);
+        } catch (err) {
+          console.error("Failed to parse chat payload", err);
+        }
+      }
+      const messageList = rawBody.messages || [];
+      const selectedSpace = rawBody.space ?? space;
+      const lastUserMessage = [...messageList].reverse().find((m) => m.role === "user");
+      const question = typeof lastUserMessage?.content === "string"
+        ? lastUserMessage.content
+        : Array.isArray(lastUserMessage?.content)
+        ? lastUserMessage.content.map((p) => (typeof p === "string" ? p : p.text || "")).join("")
+        : "";
 
-    // 2) auth headers similar to useApi
-    const raw = localStorage.getItem("auth");
-    const token = raw ? JSON.parse(raw).token : null;
-    const headers = { "Content-Type": "application/json" };
-    if (token) headers["Authorization"] = `Bearer ${token}`;
+      const authRaw = localStorage.getItem("auth");
+      const token = authRaw ? JSON.parse(authRaw).token : null;
+      const headers = { "Content-Type": "application/json" };
+      if (token) headers["Authorization"] = `Bearer ${token}`;
 
-    // 3) insert placeholder bot message; we'll set cumulative text as it streams
-    setMessages((m) => [
-      ...m,
-      { role: "bot", text: "", citations: [], file_url: null, streaming: true },
-    ]);
+      lastAssistantMetaRef.current = { citations: [], file_url: null };
 
-    try {
       const res = await fetch(`${API_BASE}/v1/chat/stream`, {
         method: "POST",
         headers,
-        body: JSON.stringify({ question, space }),
+        body: JSON.stringify({ question, space: selectedSpace }),
       });
+
       if (!res.ok || !res.body) {
         throw new Error(`Stream error ${res.status}`);
       }
 
       const reader = res.body.getReader();
-      const decoder = new TextDecoder("utf-8");
       let buffer = "";
+      let previousText = "";
+      const finalMeta = { citations: [], file_url: null };
 
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-
-        // Split by newline (NDJSON), keep last partial in buffer
-        let lines = buffer.split("\n");
-        buffer = lines.pop() || "";
-
-        for (const rawLine of lines) {
-          const line = rawLine.trim();
-          if (!line) continue;
-
-          let evt;
+      const stream = new ReadableStream({
+        async start(controller) {
           try {
-            evt = JSON.parse(line);
-          } catch {
-            continue;
+            while (true) {
+              const { value, done } = await reader.read();
+              if (done) break;
+
+              buffer += decoder.decode(value, { stream: true });
+              const lines = buffer.split("\n");
+              buffer = lines.pop() ?? "";
+
+              for (const rawLine of lines) {
+                const line = rawLine.trim();
+                if (!line) continue;
+
+                let evt;
+                try {
+                  evt = JSON.parse(line);
+                } catch (err) {
+                  console.error("Failed to parse stream event", err);
+                  continue;
+                }
+
+                if (evt.type === "content") {
+                  const text = evt.text ?? "";
+                  const delta = text.slice(previousText.length);
+                  previousText = text;
+                  if (delta) controller.enqueue(encoder.encode(delta));
+                } else if (evt.type === "done") {
+                  finalMeta.citations = evt.citations || [];
+                  finalMeta.file_url = evt.file_url || null;
+                } else if (evt.type === "error") {
+                  console.error("Stream error:", evt.message);
+                }
+              }
+            }
+          } catch (err) {
+            controller.error(err);
+            return;
           }
 
-          if (evt.type === "content") {
-            const text = evt.text ?? "";
-            // Assign cumulative text directly (no appending)
-            setMessages((m) => {
-              const copy = [...m];
-              const last = copy[copy.length - 1];
-              if (last?.role === "bot") {
-                last.text = text;
+          lastAssistantMetaRef.current = finalMeta;
+          controller.close();
+        },
+      });
+
+      return new Response(stream, {
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
+      });
+    },
+    onFinish: (message) => {
+      const meta = lastAssistantMetaRef.current;
+      setMessages((msgs) =>
+        msgs.map((m) =>
+          m.id === message.id
+            ? {
+                ...m,
+                data: {
+                  ...(m.data || {}),
+                  citations: meta.citations,
+                  file_url: meta.file_url,
+                },
               }
-              return copy;
-            });
-          } else if (evt.type === "done") {
-            setMessages((m) => {
-              const copy = [...m];
-              const last = copy[copy.length - 1];
-              if (last?.role === "bot") {
-                last.text = evt.answer ?? last.text ?? "";
-                last.citations = evt.citations || [];
-                last.file_url = evt.file_url || null;
-                last.streaming = false;
-              }
-              return copy;
-            });
-          } else if (evt.type === "error") {
-            console.error("Stream error:", evt.message);
-          }
-        }
-      }
-    } catch (err) {
-      console.error("Streaming failed", err);
-    } finally {
-      setQuestion("");
-      setLoading(false);
+            : m
+        )
+      );
+    },
+  });
+
+  const renderedMessages = messages
+    .filter((m) => m.role === "user" || m.role === "assistant")
+    .map((m, idx, arr) => {
+      const baseText = Array.isArray(m.content)
+        ? m.content
+            .map((part) =>
+              typeof part === "string" ? part : part?.text ?? ""
+            )
+            .join("")
+        : typeof m.content === "string"
+        ? m.content
+        : "";
+      const isStreamingAssistant =
+        m.role === "assistant" && idx === arr.length - 1 && isLoading;
+      return {
+        role: m.role === "assistant" ? "bot" : "user",
+        text: baseText,
+        citations: m.data?.citations || [],
+        file_url: m.data?.file_url || null,
+        streaming: isStreamingAssistant,
+      };
+    });
+
+  const onSubmit = (event) => {
+    if (!input.trim()) {
+      event.preventDefault();
+      return;
     }
+    handleSubmit(event);
   };
 
   return (
@@ -126,29 +189,29 @@ export default function Chat() {
 
       {/* Chat window */}
       <div className="w-full flex-1 overflow-y-auto min-h-0 space-y-4 pr-1 pb-4">
-        {messages.map((m, idx) => (
+        {renderedMessages.map((m, idx) => (
           <ChatMessage key={idx} msg={m} baseUrl={API_BASE} />
         ))}
-        {loading && <p className="text-slate-500">Generando…</p>}
+        {isLoading && <p className="text-slate-500">Generando…</p>}
       </div>
 
       {/* Input */}
-      <form onSubmit={askBot} className="flex-shrink-0 flex space-x-2">
-        <div className={`input-wrapper flex-grow relative ${question ? "caret-hidden" : ""}`}>
+      <form onSubmit={onSubmit} className="flex-shrink-0 flex space-x-2">
+        <div className={`input-wrapper flex-grow relative ${input ? "caret-hidden" : ""}`}>
           <input
             type="text"
             className="flex-grow w-full py-3 px-4 border rounded-2xl
                                 focus:outline-none focus:placeholder-transparent
                                 hover:bg-gray-50 transition-colors"
             placeholder="Pregunta lo que quieras a tu asistente legal…"
-            value={question}
-            onChange={(e) => setQuestion(e.target.value)}
+            value={input}
+            onChange={handleInputChange}
           />
         </div>
         <button
           type="submit"
           className="px-8 py-3 bg-gray-200 text-gray-900 border rounded-3xl hover:bg-gray-300 transition"
-          disabled={loading}
+          disabled={isLoading}
         >
           Enviar
         </button>


### PR DESCRIPTION
## Summary
- switch the chat route over to the Vercel AI SDK `useChat` hook instead of a hand-rolled streaming implementation
- stream responses from the backend NDJSON endpoint while preserving citation and file metadata on completion
- map SDK messages to the existing `ChatMessage` props so the UI keeps rendering bot and user turns as before

## Testing
- npm run lint *(fails: local npm install cannot resolve dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea62a15234832284a0031e5b12b019