### PR TITLE
fix dockerfile to exclude --env-file .env

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -31,4 +31,4 @@ USER appuser
 EXPOSE 8000
 
 # Start Uvicorn, honoring PORT if provided by the platform
-CMD ["sh", "-c", "uvicorn backend.app.main:app --env-file .env --host 0.0.0.0 --port ${PORT:-8000} --access-log"]
+CMD ["sh", "-c", "uvicorn backend.app.main:app --host 0.0.0.0 --port ${PORT:-8000} --access-log"]


### PR DESCRIPTION
Reason: ECS Express has its own env vars and the local .env file does not exist